### PR TITLE
stm32l552: Add missing IRQs for TIM6 & TIM7

### DIFF
--- a/data/STMicro/STM32L552.svd
+++ b/data/STMicro/STM32L552.svd
@@ -90948,6 +90948,16 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
         <description>TIM5 global interrupt</description>
         <value>048</value>
       </interrupt>
+      <interrupt>
+        <name>TIM2_6</name>
+        <description>TIM6 global interrupt</description>
+        <value>049</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM2_7</name>
+        <description>TIM7 global interrupt</description>
+        <value>050</value>
+      </interrupt>
       <registers>
         <register>
           <name>CR1</name>


### PR DESCRIPTION
IRQs for TIM6 and TIM7 are missing from the SVD for stm32l522.go, this change adds them using the same naming convention used elsewhere in the file.  IRQs are documented in section 16.3 of RM0438 Reference manual.